### PR TITLE
uses hacky solution to get the sounds out of main addon

### DIFF
--- a/VoiceOver/Utils.lua
+++ b/VoiceOver/Utils.lua
@@ -1,9 +1,8 @@
 setfenv(1, select(2, ...))
 VoiceOverUtils = {}
 
-local SOUNDS_BASE_DIR = "Interface\\AddOns\\VoiceOver\\generated\\sounds\\"
-local QUEST_SOUNDS_BASE_DIR = SOUNDS_BASE_DIR .. "quests\\"
-local GOSSIP_SOUNDS_BASE_DIR = SOUNDS_BASE_DIR .. "gossip\\"
+local QUEST_SOUNDS_BASE_DIR = VoiceOverConstants.SOUNDS_BASE_DIR .. "quests\\"
+local GOSSIP_SOUNDS_BASE_DIR = VoiceOverConstants.SOUNDS_BASE_DIR .. "gossip\\"
 
 function VoiceOverUtils:addGossipFilePathToSoundData(soundData)
     if soundData["questId"] == nil then

--- a/VoiceOver/VoiceOver.toc
+++ b/VoiceOver/VoiceOver.toc
@@ -1,17 +1,13 @@
 ## Interface: 11403
 ## Title: VoiceOver
 ## Notes: Adds voiceovers to npcs
+## RequiredDeps: VoiceOver_BasePack
 ## Version: 0.2
 
-Environment.lua
-generated\gossip_file_lookups.lua
-generated\questlog_npc_lookups.lua
-generated\sound_length_table.lua
 EventHandler.lua
 FuzzySearch.lua
 SoundQueue.lua
 SoundQueueUI.lua
 QuestOverlayUI.lua
 Utils.lua
-Compatibility.lua
 Main.lua

--- a/VoiceOver_BasePack/Main.lua
+++ b/VoiceOver_BasePack/Main.lua
@@ -1,0 +1,5 @@
+local SOUNDS_BASE_DIR = "Interface\\AddOns\\VoiceOver_BasePack\\generated\\sounds\\"
+
+VoiceOverConstants = {
+    SOUNDS_BASE_DIR = SOUNDS_BASE_DIR
+}

--- a/VoiceOver_BasePack/VoiceOver_BasePack.toc
+++ b/VoiceOver_BasePack/VoiceOver_BasePack.toc
@@ -1,0 +1,9 @@
+## Interface: 11403
+## Title: VoiceOver Base Sound Pack
+## Notes: Contains all the sounds for vanilla
+## Version: 0.2
+
+generated/gossip_file_lookups.lua
+generated/questlog_npc_lookups.lua
+generated/sound_length_table.lua
+Main.lua


### PR DESCRIPTION
originally I had the grand idea of splitting the addon up by a module system and just making the BasePack the primary module which is the fallback for if any other modules that were registered didn't define a voice for a given gossip/quest

The issue is holy molly is kinda complicated.

This is a PR to suggest a quick hacky work around getting the sound files out of the release so that we can distribute the `VoiceOver_BasePack` via seperate addon but in the same release for now and at a later time we can release the `VoiceOver_BasePack` via torrent if github complains about the amount of transfers we are doing

I am not sure how to bundle this all up and fully validate it in game, instead I have been copy pasting files back and forth so this might need a little fix up if I mseed up my copy paste.

Yes the addon RequiredDeps order feels bad, but it makes loading the lookups and sound lengths easy peasy, I will eventually move the lookups and table into module functions and have the main addon manage this better but that's when I have time for the module system