### PR TITLE
Feature Contribution: Sync Audio with Gossip/Quest Frame (#48)

### DIFF
--- a/AI_VoiceOver/Options.lua
+++ b/AI_VoiceOver/Options.lua
@@ -246,10 +246,22 @@ local GeneralTab =
                         Addon.soundQueue.ui:RefreshConfig()
                     end,
                 },
+                LineBreak2 = { type = "description", name = "", order = 4 },
+                ToggleSyncToWindowState = {
+                    type = "toggle",
+                    order = 5,
+                    width = 2,
+                    name = "Sync Dialog to Window State",
+                    desc = "VoiceOver dialog will automatically stop when the gossip/quest window is closed.",
+                    get = function(info) return Addon.db.profile.Audio.StopAudioOnDisengage end,
+                    set = function(info, value)
+                        Addon.db.profile.Audio.StopAudioOnDisengage = value
+                    end,
+                },
                 AutoToggleDialog = {
                     type = "toggle",
                     width = 2.25,
-                    order = 4,
+                    order = 6,
                     name = "Mute Vocal NPCs Greetings While VoiceOver is Playing",
                     desc = "While VoiceOver is playing, the Dialog channel will be muted.",
                     get = function(info) return Addon.db.profile.Audio.AutoToggleDialog end,

--- a/AI_VoiceOver/SoundQueue.lua
+++ b/AI_VoiceOver/SoundQueue.lua
@@ -127,6 +127,10 @@ function SoundQueue:RemoveSoundFromQueue(soundData)
         end
     end
 
+    if not removedIndex then
+        return
+    end
+
     if soundData.stopCallback then
         soundData.stopCallback()
     end


### PR DESCRIPTION
Added an option to automatically stop/remove the audio associated with the current gossip/quest frame. This won't affect manually queued up quest dialog. 

Also fixed a slight error in tooltip for hiding frame option.

