### PR TITLE
add lang selector, change 11labs model to support multilang

### DIFF
--- a/cli-main.py
+++ b/cli-main.py
@@ -11,6 +11,24 @@ from tts_cli import utils
 
 def prompt_user(tts_processor):
 
+        #lang
+    lang_choices = [
+        (0, "enUS/enGB"),
+        (1, "koKR"),
+        (2, "frFR"),
+        (3, "deDE"),
+        (4, "zhCN"),
+        (5, "zhTW"),
+        (6, "esES"),
+        (7, "esMX"),
+        (8, "ruRU"),
+    ]
+    lang_id = radiolist_dialog(
+        title="Select a lang",
+        text="Choose a lang:",
+        values=lang_choices,
+    ).run()
+
     #map
     map_choices = [
         (-1, "All (includes dungeons)"),
@@ -35,7 +53,7 @@ def prompt_user(tts_processor):
         df = query_dataframe_for_area(xrange, yrange, map_id)
     else:
         (xrange, yrange) = 'all', 'all'
-        df = query_dataframe_for_all_quests_and_gossip()
+        df = query_dataframe_for_all_quests_and_gossip(lang_id)
     
     # Get unique race-gender combinations
     unique_race_gender_combos = df[[
@@ -102,7 +120,8 @@ def prompt_user(tts_processor):
 
     confirmed = yes_no_dialog(
         title="Summary",
-        text=f"Selected Map: {map_choices[map_id][1]}\n"
+        text=f"Selected lang: {lang_choices[lang_id][1]}\n"
+             f"Selected Map: {map_choices[map_id][1]}\n"
              f"Coordinate Range: x={xrange}, y={yrange}\n"
              f"Selected Voices: {', '.join(selected_voice_names)}\n"
              f"Approximate Text Characters: {total_characters}",

--- a/tts_cli/tts_utils.py
+++ b/tts_cli/tts_utils.py
@@ -99,8 +99,10 @@ class TTSProcessor:
 
         voice_id = self.voice_map[voice]
         url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
+        # use multilingual model to support more languages 
         payload = {
             "text": text,
+            "model_id": "eleven_multilingual_v2",
             "voice_settings": {
                 "stability": 0.28,
                 "similarity_boost": .992


### PR DESCRIPTION
- This PR will add a new lang selector in the CLI.
- The picked value of this selector will be used to determine which locale should be used, when talking to the 11labs API.
- It will also change the 11labs model to a multilang one, support other languages than english.
- you could add a condition to use another model for english texts (turbo for example)
- my brain stopped working half way through, someone could be so kind to add it also to the area-select method
- for now, its working. I get a lot of [429] from the elevenlabs API, but I guess thats something to figure out for later