### PR TITLE
Fixed playButton position

### DIFF
--- a/AI_VoiceOver/QuestOverlayUI.lua
+++ b/AI_VoiceOver/QuestOverlayUI.lua
@@ -39,7 +39,7 @@ function QuestOverlayUI:UpdateQuestTitle(questLogTitleFrame, playButton, normalT
         normalText:SetText(text)
     end
 
-    playButton:SetPoint("LEFT", normalText, "LEFT", 4, 0)
+    playButton:SetPoint("RIGHT", normalText, "LEFT")
 
     local formatedText = prefix .. string.trim(normalText:GetText() or "")
 


### PR DESCRIPTION
playButton was overlapping quest text in the quest log (Turtle WoW client version 11200). By changing playButton's anchor point it will remain to the left of the quest text.